### PR TITLE
Call 'OnPedExitedSphereEx' event properly.

### DIFF
--- a/v-events/client.js
+++ b/v-events/client.js
@@ -118,7 +118,7 @@ addEventHandler("OnEntityProcess", function (event, entity) {
 							sphere = tempSphere;
 						}
 					} else {
-						if (sphere != null) {
+						if (sphere == tempSphere) {
 							triggerEvent("OnPedExitedSphereEx", entity, entity, tempSphere);
 							triggerNetworkEvent("OnPedExitedSphereEx", entity.id, tempSphere.id);
 							sphere = null;


### PR DESCRIPTION
forEach loop scans for all created spheres, so when there are more than one sphere and we are not in "enter" distance to the any other found spheres, the OnPedExitedSphereEx event will be called. Checking 'sphere == tempSphere' will call exit event only when we are exiting the real entered sphere.