### PR TITLE
Fix issue after deleting markers/spheres before exiting them

### DIFF
--- a/v-events/client.js
+++ b/v-events/client.js
@@ -132,6 +132,11 @@ addEventHandler("OnEntityProcess", function (event, entity) {
 					}
 				});
 			}
+			
+			// Set sphere variable to null, to fix issue when markers were deleted/hidden before exiting them.
+			if (sphere && sphere.id == -1) {
+				sphere = null;
+			}
 		}
 	}
 });


### PR DESCRIPTION
Set sphere variable to null when sphere was destroyed or hidden before exiting it. In that case, the 'OnPedEnteredSphereEx' event wasn't called anymore.