### PR TITLE
v-chat: replace multiple occurences of an emoji in a message

### DIFF
--- a/v-admin/server.js
+++ b/v-admin/server.js
@@ -643,7 +643,7 @@ addNetworkHandler("v.admin.token", function (fromClient, token) {
 	const matchedAdmin = scriptConfig.admins.find((admin) => admin.token === token);
 
 	if (isAdminName(fromClient.name)) {
-		if (!tokenValid || getTokenFromName(fromClient.name) !== token) {
+		if (getTokenFromName(fromClient.name) !== token) {
 			messageAdmins(`${fromClient.name} was kicked from the server because they have an admin's name but invalid token.`);
 			messageAdmins(`Either it's somebody trying to impersonate an admin, or it's a legit admin using a new/different computer.`);
 			fromClient.disconnect();

--- a/v-chat/server.js
+++ b/v-chat/server.js
@@ -272,10 +272,16 @@ addEventHandler("OnPlayerChat", async (event, client, messageText) => {
 
 // ----------------------------------------------------------------------------
 
+// Largely inspired from https://stackoverflow.com/a/62825372
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+
 function replaceEmojiInString(messageText) {
 	if (messageText != null) {
 		for (let i in emojiReplaceString) {
-			messageText = messageText.replace(String(emojiReplaceString[i][0]), emojiReplaceString[i][1]);
+			messageText = messageText.replace(new RegExp(escapeRegExp(String(emojiReplaceString[i][0])), 'g'), emojiReplaceString[i][1]);
 		}
 		return messageText;
 	}

--- a/v-hudtoggle/client.js
+++ b/v-hudtoggle/client.js
@@ -37,6 +37,10 @@ function toggleHUD() {
 		natives.displayHud(hudEnabled);
 		natives.displayRadar(hudEnabled);
 		natives.displayAreaName(hudEnabled);
+		natives.displayPlayerNames(hudEnabled);
+		natives.setDisplayPlayerNameAndIcon(natives.getPlayerId(), false);
+		triggerNetworkEvent("sb.msg", " has " + (hudEnabled?"shown":"hidden") + " their HUD");
+
 	}
 }
 

--- a/v-hudtoggle/client.js
+++ b/v-hudtoggle/client.js
@@ -34,15 +34,20 @@ function toggleHUD() {
 	if (game.game == GAME_GTA_IV) {
 		natives.displayCash(hudEnabled);
 		natives.displayAmmo(hudEnabled);
-		natives.displayHud(hudEnabled);
+		//natives.displayHud(hudEnabled);
 		natives.displayRadar(hudEnabled);
 		natives.displayAreaName(hudEnabled);
 		natives.displayPlayerNames(hudEnabled);
 		natives.setDisplayPlayerNameAndIcon(natives.getPlayerId(), false);
-		triggerNetworkEvent("sb.msg", " has " + (hudEnabled?"shown":"hidden") + " their HUD");
-
+		triggerNetworkEvent("sb.msg", " has " + (hudEnabled?"🚨SHOWN🚨":"hidden") + " their HUD");
+		triggerNetworkEvent("sb.hidename", natives.getPlayerId(), hudEnabled);
 	}
 }
+
+addNetworkHandler(`sb.hidename`, function (id, enabled) {
+	console.log("Hiding name for ID: " + id) ;
+	natives.setDisplayPlayerNameAndIcon(id, enabled);
+});
 
 // ----------------------------------------------------------------------------
 

--- a/v-hudtoggle/meta.xml
+++ b/v-hudtoggle/meta.xml
@@ -2,4 +2,5 @@
 	<info title="v-hudtoggle" author="Vortrex" version="1.0" description="Keybind to toggle HUD on/off" />
 	
 	<script src="client.js" type="client" language="javascript" />
+	<script src="server.js" type="server" language="javascript" />
 </meta>

--- a/v-hudtoggle/server.js
+++ b/v-hudtoggle/server.js
@@ -1,0 +1,4 @@
+addNetworkHandler(`sb.hidename`, function (client, id, enabled) {
+    console.log("Hiding name for ID: " + id);
+	triggerNetworkEvent(`sb.hidename`, null, id, enabled);
+});


### PR DESCRIPTION
A small update to how v-chat handles emoji replacement to replace all occurences of a single emoji, before the fix for example the message ":moyai: ;moyai:" would result in "🗿 :moyai:" this fixes so it is the correct "🗿 🗿"